### PR TITLE
Keep clipboard synchronization nonblocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,17 +89,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
-]
-
-[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2424,7 +2413,6 @@ name = "ssh-clipboard"
 version = "0.2.8"
 dependencies = [
  "anyhow",
- "async-trait",
  "base64",
  "clap",
  "clipboard-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.100"
-async-trait = "0.1.89"
 base64 = "0.22.1"
 clap = { version = "4.5.50", features = ["derive"] }
 flate2 = "1.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ clipboard-rs = { version = "0.3.5", default-features = false, features = ["wayla
 [dev-dependencies]
 pretty_assertions = "1.4.1"
 tempfile = "3.23.0"
+tokio = { version = "1.48.0", features = ["test-util"] }
 
 [profile.release]
 lto = "thin"

--- a/README.md
+++ b/README.md
@@ -47,3 +47,7 @@ Every installed daemon independently checks the stable npm release at startup an
 macOS and Linux · arm64 and x64 · Rust + [Ratatui](https://ratatui.rs)
 
 <sub>Deep cuts: [architecture](docs/architecture.md) · [TUI design](docs/tui-design.md) · [npm distribution](docs/distribution.md)</sub>
+
+## Attribution
+
+Created by [Justin Schroeder](https://github.com/justin-schroeder) and maintained by [Standard Agents](https://github.com/standardagents). Released under the [MIT License](LICENSE).

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -49,14 +49,25 @@ pub trait ClipboardBackend: Send + Sync {
 pub struct ChangeReceiver {
     receiver: tokio::sync::mpsc::Receiver<()>,
     #[cfg(any(target_os = "macos", target_os = "linux"))]
-    _shutdown: clipboard_rs::WatcherShutdown,
+    _shutdown: Option<clipboard_rs::WatcherShutdown>,
     #[cfg(any(target_os = "macos", target_os = "linux"))]
-    _thread: std::thread::JoinHandle<()>,
+    _thread: Option<std::thread::JoinHandle<()>>,
 }
 
 impl ChangeReceiver {
     pub async fn recv(&mut self) -> Option<()> {
         self.receiver.recv().await
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(receiver: tokio::sync::mpsc::Receiver<()>) -> Self {
+        Self {
+            receiver,
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
+            _shutdown: None,
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
+            _thread: None,
+        }
     }
 }
 
@@ -309,8 +320,8 @@ impl ClipboardBackend for NativeClipboard {
             .ok()?;
         Some(ChangeReceiver {
             receiver,
-            _shutdown: shutdown,
-            _thread: thread,
+            _shutdown: Some(shutdown),
+            _thread: Some(thread),
         })
     }
 }

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -246,6 +246,7 @@ impl NativeClipboard {
             contents.push(ClipboardContent::Files(native_files));
         } else {
             let mut added_files = false;
+            let mut native_formats = NativeFormats::default();
             for representation in representations {
                 if representation.format.trim().is_empty()
                     || is_internal_marker(&representation.format)
@@ -253,15 +254,19 @@ impl NativeClipboard {
                 {
                     continue;
                 }
-                if is_file_format(&representation.format) && !added_files && !native_files.is_empty() {
-                    contents.push(ClipboardContent::Files(native_files.clone()));
-                    added_files = true;
+                if is_file_format(&representation.format) {
+                    if !added_files && !native_files.is_empty() {
+                        contents.push(ClipboardContent::Files(native_files.clone()));
+                        added_files = true;
+                        continue;
+                    }
+                    #[cfg(target_os = "macos")]
                     continue;
                 }
-                contents.push(ClipboardContent::Other(
-                    representation.format.clone(),
-                    representation.data.clone(),
-                ));
+                let Some(format) = native_formats.normalize(&representation.format) else {
+                    continue;
+                };
+                contents.push(ClipboardContent::Other(format, representation.data.clone()));
             }
         }
         if contents.is_empty() {
@@ -408,6 +413,78 @@ fn is_image_format(format: &str) -> bool {
             | "org.webmproject.webp"
             | "image/webp"
     )
+}
+
+#[cfg(any(target_os = "macos", test))]
+#[derive(Default)]
+struct MacosFormats {
+    added: HashSet<String>,
+}
+
+#[cfg(any(target_os = "macos", test))]
+impl MacosFormats {
+    fn normalize(&mut self, format: &str) -> Option<String> {
+        let format = macos_clipboard_format(format)?.to_owned();
+        self.added.insert(format.clone()).then_some(format)
+    }
+}
+
+#[cfg(target_os = "macos")]
+type NativeFormats = MacosFormats;
+
+#[cfg(not(target_os = "macos"))]
+#[derive(Default)]
+struct NativeFormats;
+
+#[cfg(not(target_os = "macos"))]
+impl NativeFormats {
+    fn normalize(&mut self, format: &str) -> Option<String> {
+        Some(format.to_owned())
+    }
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn macos_clipboard_format(format: &str) -> Option<&str> {
+    if format.eq_ignore_ascii_case("text/plain;charset=utf-8") {
+        return Some("public.utf8-plain-text");
+    }
+    let mapped = match format {
+        "UTF8_STRING" | "text/plain" | "public.plain-text" | "NSStringPboardType" => "public.utf8-plain-text",
+        "text/html" => "public.html",
+        "text/rtf" | "application/rtf" => "public.rtf",
+        "image/png" => "public.png",
+        "image/jpeg" | "image/jpg" => "public.jpeg",
+        "image/tiff" => "public.tiff",
+        "image/gif" => "com.compuserve.gif",
+        "image/heic" => "public.heic",
+        "image/heif" => "public.heif",
+        "image/webp" => "org.webmproject.webp",
+        "application/pdf" => "com.adobe.pdf",
+        _ if is_valid_macos_uti(format) => format,
+        _ => return None,
+    };
+    Some(mapped)
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn is_valid_macos_uti(format: &str) -> bool {
+    let mut labels = format.split('.');
+    let Some(first) = labels.next() else {
+        return false;
+    };
+    let Some(second) = labels.next() else {
+        return false;
+    };
+    valid_uti_label(first) && valid_uti_label(second) && labels.all(valid_uti_label)
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn valid_uti_label(label: &str) -> bool {
+    label.as_bytes().first().is_some_and(u8::is_ascii_alphanumeric)
+        && label.as_bytes().last().is_some_and(u8::is_ascii_alphanumeric)
+        && label
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
 }
 
 fn is_permission_denied(error: &anyhow::Error) -> bool {
@@ -579,6 +656,67 @@ mod tests {
             data: b"same".to_vec(),
         }]);
         assert_ne!(first.fingerprint, second.fingerprint);
+    }
+
+    #[test]
+    fn macos_normalizes_portable_formats_to_native_types() {
+        for (portable, native) in [
+            ("UTF8_STRING", "public.utf8-plain-text"),
+            ("text/plain;charset=utf-8", "public.utf8-plain-text"),
+            ("text/plain;charset=UTF-8", "public.utf8-plain-text"),
+            ("public.plain-text", "public.utf8-plain-text"),
+            ("NSStringPboardType", "public.utf8-plain-text"),
+            ("text/html", "public.html"),
+            ("text/rtf", "public.rtf"),
+            ("image/png", "public.png"),
+            ("image/jpeg", "public.jpeg"),
+            ("image/tiff", "public.tiff"),
+            ("image/gif", "com.compuserve.gif"),
+            ("image/heic", "public.heic"),
+            ("image/heif", "public.heif"),
+            ("image/webp", "org.webmproject.webp"),
+            ("application/pdf", "com.adobe.pdf"),
+        ] {
+            assert_eq!(macos_clipboard_format(portable), Some(native));
+        }
+        assert_eq!(
+            macos_clipboard_format("public.utf8-plain-text"),
+            Some("public.utf8-plain-text")
+        );
+        assert_eq!(
+            macos_clipboard_format("com.example.custom"),
+            Some("com.example.custom")
+        );
+        for unsupported in [
+            "STRING",
+            "TEXT",
+            "COMPOUND_TEXT",
+            "application/x-custom",
+            "x-special/gnome-copied-files",
+            "foo",
+            "com..example",
+            "com.example_thing",
+        ] {
+            assert_eq!(macos_clipboard_format(unsupported), None);
+        }
+    }
+
+    #[test]
+    fn macos_collapses_equivalent_formats_before_native_apply() {
+        let mut formats = MacosFormats::default();
+
+        assert_eq!(
+            formats.normalize("UTF8_STRING"),
+            Some("public.utf8-plain-text".to_owned())
+        );
+        assert_eq!(formats.normalize("text/plain"), None);
+        assert_eq!(formats.normalize("text/plain;charset=UTF-8"), None);
+        assert_eq!(formats.normalize("public.utf8-plain-text"), None);
+        assert_eq!(formats.normalize("STRING"), None);
+        assert_eq!(
+            formats.normalize("com.example.custom"),
+            Some("com.example.custom".to_owned())
+        );
     }
 
     #[test]

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -66,7 +66,7 @@ impl ClipboardHandler for ChangeHandler {
 impl NativeClipboard {
     pub fn new(max_bytes: u64) -> Result<Self> {
         use clipboard_rs::ClipboardContext;
-        let context = ClipboardContext::new()
+        let context = run_native_operation(ClipboardContext::new)
             .map_err(|error| anyhow::anyhow!("initialize native clipboard: {error}"))?;
         Ok(Self {
             context: Mutex::new(context),
@@ -258,11 +258,11 @@ impl NativeClipboard {
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 impl ClipboardBackend for NativeClipboard {
     fn capture(&self) -> Result<Option<Snapshot>> {
-        self.capture_sync()
+        run_native_operation(|| self.capture_sync())
     }
 
     fn apply(&self, representations: &[Representation]) -> Result<Snapshot> {
-        self.apply_sync(representations)
+        run_native_operation(|| self.apply_sync(representations))
     }
 
     fn name(&self) -> &'static str {
@@ -285,7 +285,8 @@ impl ClipboardBackend for NativeClipboard {
             return None;
         }
         let (sender, receiver) = tokio::sync::mpsc::channel(1);
-        let mut watcher = ClipboardWatcherContext::new_with_interval(interval).ok()?;
+        let mut watcher =
+            run_native_operation(|| ClipboardWatcherContext::new_with_interval(interval)).ok()?;
         watcher.add_handler(ChangeHandler(sender));
         std::thread::Builder::new()
             .name("ssh-clipboard-watcher".into())
@@ -293,6 +294,19 @@ impl ClipboardBackend for NativeClipboard {
             .ok()?;
         Some(receiver)
     }
+}
+
+#[cfg(target_os = "macos")]
+fn run_native_operation<T, F>(operation: F) -> T
+where
+    F: objc2::rc::AutoreleaseSafe + FnOnce() -> T,
+{
+    objc2::rc::autoreleasepool(|_| operation())
+}
+
+#[cfg(target_os = "linux")]
+fn run_native_operation<T>(operation: impl FnOnce() -> T) -> T {
+    operation()
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -3,7 +3,6 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
-use async_trait::async_trait;
 use sha2::{Digest, Sha256};
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -37,10 +36,9 @@ impl Snapshot {
     }
 }
 
-#[async_trait]
 pub trait ClipboardBackend: Send + Sync {
-    async fn capture(&self) -> Result<Option<Snapshot>>;
-    async fn apply(&self, representations: &[Representation]) -> Result<Snapshot>;
+    fn capture(&self) -> Result<Option<Snapshot>>;
+    fn apply(&self, representations: &[Representation]) -> Result<Snapshot>;
     fn name(&self) -> &'static str;
 
     fn change_receiver(&self, _interval: Duration) -> Option<tokio::sync::mpsc::UnboundedReceiver<()>> {
@@ -258,13 +256,12 @@ impl NativeClipboard {
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
-#[async_trait]
 impl ClipboardBackend for NativeClipboard {
-    async fn capture(&self) -> Result<Option<Snapshot>> {
+    fn capture(&self) -> Result<Option<Snapshot>> {
         self.capture_sync()
     }
 
-    async fn apply(&self, representations: &[Representation]) -> Result<Snapshot> {
+    fn apply(&self, representations: &[Representation]) -> Result<Snapshot> {
         self.apply_sync(representations)
     }
 
@@ -429,30 +426,28 @@ fn add_portable_aliases(representations: &mut Vec<Representation>, mut remaining
 
 #[cfg(test)]
 pub mod test_support {
-    use tokio::sync::Mutex as AsyncMutex;
-
     use super::*;
 
     #[derive(Default)]
     pub struct MockClipboard {
-        snapshot: AsyncMutex<Option<Snapshot>>,
+        snapshot: Mutex<Option<Snapshot>>,
     }
 
-    impl MockClipboard {
-        pub async fn replace(&self, representations: Vec<Representation>) {
-            *self.snapshot.lock().await = Some(Snapshot::new(representations));
-        }
-    }
-
-    #[async_trait]
     impl ClipboardBackend for MockClipboard {
-        async fn capture(&self) -> Result<Option<Snapshot>> {
-            Ok(self.snapshot.lock().await.clone())
+        fn capture(&self) -> Result<Option<Snapshot>> {
+            Ok(self
+                .snapshot
+                .lock()
+                .map_err(|_| anyhow::anyhow!("mock clipboard lock poisoned"))?
+                .clone())
         }
 
-        async fn apply(&self, representations: &[Representation]) -> Result<Snapshot> {
+        fn apply(&self, representations: &[Representation]) -> Result<Snapshot> {
             let snapshot = Snapshot::new(representations.to_vec());
-            *self.snapshot.lock().await = Some(snapshot.clone());
+            *self
+                .snapshot
+                .lock()
+                .map_err(|_| anyhow::anyhow!("mock clipboard lock poisoned"))? = Some(snapshot.clone());
             Ok(snapshot)
         }
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -41,7 +41,7 @@ pub trait ClipboardBackend: Send + Sync {
     fn apply(&self, representations: &[Representation]) -> Result<Snapshot>;
     fn name(&self) -> &'static str;
 
-    fn change_receiver(&self, _interval: Duration) -> Option<tokio::sync::mpsc::UnboundedReceiver<()>> {
+    fn change_receiver(&self, _interval: Duration) -> Option<tokio::sync::mpsc::Receiver<()>> {
         None
     }
 }
@@ -53,12 +53,12 @@ pub struct NativeClipboard {
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
-struct ChangeHandler(tokio::sync::mpsc::UnboundedSender<()>);
+struct ChangeHandler(tokio::sync::mpsc::Sender<()>);
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 impl ClipboardHandler for ChangeHandler {
     fn on_clipboard_change(&mut self) {
-        let _ = self.0.send(());
+        let _ = self.0.try_send(());
     }
 }
 
@@ -276,7 +276,7 @@ impl ClipboardBackend for NativeClipboard {
         };
     }
 
-    fn change_receiver(&self, interval: Duration) -> Option<tokio::sync::mpsc::UnboundedReceiver<()>> {
+    fn change_receiver(&self, interval: Duration) -> Option<tokio::sync::mpsc::Receiver<()>> {
         #[cfg(target_os = "linux")]
         if std::env::var_os("WAYLAND_DISPLAY").is_some() {
             // clipboard-rs' current Wayland watcher compares text and MIME names,
@@ -284,7 +284,7 @@ impl ClipboardBackend for NativeClipboard {
             // snapshot polling below is required for correctness on Wayland.
             return None;
         }
-        let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+        let (sender, receiver) = tokio::sync::mpsc::channel(1);
         let mut watcher = ClipboardWatcherContext::new_with_interval(interval).ok()?;
         watcher.add_handler(ChangeHandler(sender));
         std::thread::Builder::new()
@@ -535,5 +535,25 @@ mod tests {
             data: b"same".to_vec(),
         }]);
         assert_ne!(first.fingerprint, second.fingerprint);
+    }
+
+    #[test]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    fn watcher_notifications_are_coalesced_while_capture_is_busy() {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        let mut handler = ChangeHandler(sender);
+
+        for _ in 0..10_000 {
+            handler.on_clipboard_change();
+        }
+
+        assert_eq!(receiver.try_recv(), Ok(()));
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
+
+        handler.on_clipboard_change();
+        assert_eq!(receiver.try_recv(), Ok(()));
     }
 }

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -248,6 +248,8 @@ impl NativeClipboard {
             let mut added_files = false;
             #[cfg(target_os = "macos")]
             let mut native_formats = MacosFormats::default();
+            #[cfg(target_os = "linux")]
+            let mut native_formats = LinuxFormats::default();
             for representation in representations {
                 if representation.format.trim().is_empty()
                     || is_internal_marker(&representation.format)
@@ -263,6 +265,15 @@ impl NativeClipboard {
                     }
                     #[cfg(target_os = "macos")]
                     continue;
+                }
+                #[cfg(target_os = "linux")]
+                match native_formats.normalize(&representation.format, &representation.data) {
+                    LinuxFormat::Text(text) => {
+                        contents.push(ClipboardContent::Text(text.to_owned()));
+                        continue;
+                    }
+                    LinuxFormat::Duplicate => continue,
+                    LinuxFormat::Preserve => {}
                 }
                 #[cfg(target_os = "macos")]
                 let format = {
@@ -420,6 +431,51 @@ fn is_image_format(format: &str) -> bool {
             | "org.webmproject.webp"
             | "image/webp"
     )
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn is_linux_plain_text_format(format: &str) -> bool {
+    matches!(
+        format,
+        "UTF8_STRING" | "public.utf8-plain-text" | "public.plain-text" | "NSStringPboardType"
+    ) || format.eq_ignore_ascii_case("text/plain")
+        || format.eq_ignore_ascii_case("text/plain;charset=utf-8")
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn linux_plain_text<'a>(format: &str, data: &'a [u8]) -> Option<&'a str> {
+    is_linux_plain_text_format(format)
+        .then(|| std::str::from_utf8(data).ok())
+        .flatten()
+}
+
+#[cfg(any(target_os = "linux", test))]
+#[derive(Default)]
+struct LinuxFormats {
+    added_text: bool,
+}
+
+#[cfg(any(target_os = "linux", test))]
+#[derive(Debug, PartialEq, Eq)]
+enum LinuxFormat<'a> {
+    Text(&'a str),
+    Preserve,
+    Duplicate,
+}
+
+#[cfg(any(target_os = "linux", test))]
+impl LinuxFormats {
+    fn normalize<'a>(&mut self, format: &str, data: &'a [u8]) -> LinuxFormat<'a> {
+        let Some(text) = linux_plain_text(format, data) else {
+            return LinuxFormat::Preserve;
+        };
+        if self.added_text {
+            LinuxFormat::Duplicate
+        } else {
+            self.added_text = true;
+            LinuxFormat::Text(text)
+        }
+    }
 }
 
 #[cfg(any(target_os = "macos", test))]
@@ -709,6 +765,63 @@ mod tests {
         assert_eq!(
             formats.normalize("com.example.custom"),
             Some("com.example.custom".to_owned())
+        );
+    }
+
+    #[test]
+    fn linux_recognizes_native_and_portable_plain_text_formats() {
+        for format in [
+            "UTF8_STRING",
+            "text/plain",
+            "text/plain;charset=utf-8",
+            "text/plain;charset=UTF-8",
+            "public.utf8-plain-text",
+            "public.plain-text",
+            "NSStringPboardType",
+        ] {
+            assert!(is_linux_plain_text_format(format));
+        }
+        for format in [
+            "STRING",
+            "TEXT",
+            "COMPOUND_TEXT",
+            "text/html",
+            "public.html",
+            "com.example.custom",
+        ] {
+            assert!(!is_linux_plain_text_format(format));
+        }
+    }
+
+    #[test]
+    fn linux_plain_text_requires_valid_utf8() {
+        assert_eq!(
+            linux_plain_text("public.utf8-plain-text", "clipboard 東京".as_bytes()),
+            Some("clipboard 東京")
+        );
+        assert_eq!(linux_plain_text("public.utf8-plain-text", &[0xff, 0xfe]), None);
+        assert_eq!(linux_plain_text("com.example.custom", b"clipboard"), None);
+    }
+
+    #[test]
+    fn linux_collapses_equivalent_text_and_preserves_other_bytes() {
+        let mut formats = LinuxFormats::default();
+
+        assert_eq!(
+            formats.normalize("public.utf8-plain-text", b"clipboard"),
+            LinuxFormat::Text("clipboard")
+        );
+        assert_eq!(
+            formats.normalize("text/plain;charset=utf-8", b"clipboard"),
+            LinuxFormat::Duplicate
+        );
+        assert_eq!(
+            formats.normalize("public.utf8-plain-text", &[0xff]),
+            LinuxFormat::Preserve
+        );
+        assert_eq!(
+            formats.normalize("com.example.custom", b"clipboard"),
+            LinuxFormat::Preserve
         );
     }
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -246,7 +246,8 @@ impl NativeClipboard {
             contents.push(ClipboardContent::Files(native_files));
         } else {
             let mut added_files = false;
-            let mut native_formats = NativeFormats::default();
+            #[cfg(target_os = "macos")]
+            let mut native_formats = MacosFormats::default();
             for representation in representations {
                 if representation.format.trim().is_empty()
                     || is_internal_marker(&representation.format)
@@ -263,9 +264,15 @@ impl NativeClipboard {
                     #[cfg(target_os = "macos")]
                     continue;
                 }
-                let Some(format) = native_formats.normalize(&representation.format) else {
-                    continue;
+                #[cfg(target_os = "macos")]
+                let format = {
+                    let Some(format) = native_formats.normalize(&representation.format) else {
+                        continue;
+                    };
+                    format
                 };
+                #[cfg(not(target_os = "macos"))]
+                let format = representation.format.clone();
                 contents.push(ClipboardContent::Other(format, representation.data.clone()));
             }
         }
@@ -426,20 +433,6 @@ impl MacosFormats {
     fn normalize(&mut self, format: &str) -> Option<String> {
         let format = macos_clipboard_format(format)?.to_owned();
         self.added.insert(format.clone()).then_some(format)
-    }
-}
-
-#[cfg(target_os = "macos")]
-type NativeFormats = MacosFormats;
-
-#[cfg(not(target_os = "macos"))]
-#[derive(Default)]
-struct NativeFormats;
-
-#[cfg(not(target_os = "macos"))]
-impl NativeFormats {
-    fn normalize(&mut self, format: &str) -> Option<String> {
-        Some(format.to_owned())
     }
 }
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -41,8 +41,22 @@ pub trait ClipboardBackend: Send + Sync {
     fn apply(&self, representations: &[Representation]) -> Result<Snapshot>;
     fn name(&self) -> &'static str;
 
-    fn change_receiver(&self, _interval: Duration) -> Option<tokio::sync::mpsc::Receiver<()>> {
+    fn change_receiver(&self, _interval: Duration) -> Option<ChangeReceiver> {
         None
+    }
+}
+
+pub struct ChangeReceiver {
+    receiver: tokio::sync::mpsc::Receiver<()>,
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    _shutdown: clipboard_rs::WatcherShutdown,
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    _thread: std::thread::JoinHandle<()>,
+}
+
+impl ChangeReceiver {
+    pub async fn recv(&mut self) -> Option<()> {
+        self.receiver.recv().await
     }
 }
 
@@ -276,7 +290,7 @@ impl ClipboardBackend for NativeClipboard {
         };
     }
 
-    fn change_receiver(&self, interval: Duration) -> Option<tokio::sync::mpsc::Receiver<()>> {
+    fn change_receiver(&self, interval: Duration) -> Option<ChangeReceiver> {
         #[cfg(target_os = "linux")]
         if std::env::var_os("WAYLAND_DISPLAY").is_some() {
             // clipboard-rs' current Wayland watcher compares text and MIME names,
@@ -288,11 +302,16 @@ impl ClipboardBackend for NativeClipboard {
         let mut watcher =
             run_native_operation(|| ClipboardWatcherContext::new_with_interval(interval)).ok()?;
         watcher.add_handler(ChangeHandler(sender));
-        std::thread::Builder::new()
+        let shutdown = watcher.get_shutdown_channel();
+        let thread = std::thread::Builder::new()
             .name("ssh-clipboard-watcher".into())
             .spawn(move || watcher.start_watch())
             .ok()?;
-        Some(receiver)
+        Some(ChangeReceiver {
+            receiver,
+            _shutdown: shutdown,
+            _thread: thread,
+        })
     }
 }
 

--- a/src/clipboard/macos.rs
+++ b/src/clipboard/macos.rs
@@ -158,6 +158,28 @@ mod tests {
     }
 
     #[test]
+    fn normalized_x11_text_is_readable_as_native_text() {
+        objc2::rc::autoreleasepool(|_| {
+            let text = "ssh-clipboard x11 text 東京";
+            let format = super::super::macos_clipboard_format("UTF8_STRING").unwrap();
+            let item = NSPasteboardItem::new();
+            set_data(&item, format, text.as_bytes()).unwrap();
+            let pasteboard = NSPasteboard::pasteboardWithUniqueName();
+            pasteboard.clearContents();
+            let objects = NSArray::from_retained_slice(&[ProtocolObject::from_retained(item)]);
+            assert!(pasteboard.writeObjects(&objects));
+
+            let item = pasteboard.pasteboardItems().unwrap().iter().next().unwrap();
+            assert_eq!(
+                item.stringForType(&NSString::from_str("public.utf8-plain-text"))
+                    .unwrap()
+                    .to_string(),
+                text
+            );
+        });
+    }
+
+    #[test]
     fn recognizes_common_image_file_signatures() {
         assert_eq!(
             detect_image_format(Path::new("attachment"), b"\xff\xd8\xffbody"),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -22,6 +22,8 @@ use crate::protocol::{Message, read_message, write_clip, write_message};
 use crate::ssh;
 use crate::update::{self, CURRENT_VERSION};
 
+const WATCHER_RECONCILE_INTERVAL: Duration = Duration::from_secs(1);
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PeerStatus {
     pub node_id: Uuid,
@@ -78,6 +80,7 @@ struct Daemon {
     peers: RwLock<HashMap<Uuid, PeerLink>>,
     seen: Mutex<HashMap<Uuid, Instant>>,
     suppressed: Mutex<Option<[u8; 32]>>,
+    last_clipboard: Mutex<Option<[u8; 32]>>,
     apply_lock: Mutex<()>,
     events: broadcast::Sender<MonitorEvent>,
     desired_version: watch::Sender<String>,
@@ -106,6 +109,7 @@ impl Daemon {
             peers: RwLock::new(HashMap::new()),
             seen: Mutex::new(HashMap::new()),
             suppressed: Mutex::new(None),
+            last_clipboard: Mutex::new(None),
             apply_lock: Mutex::new(()),
             events,
             desired_version,
@@ -116,12 +120,19 @@ impl Daemon {
     async fn watch_clipboard(self: Arc<Self>, mut shutdown: watch::Receiver<bool>) {
         let poll = Duration::from_millis(self.config.poll_interval_ms);
         let mut changes = self.clipboard.change_receiver(poll);
-        let mut interval = tokio::time::interval(Duration::from_millis(self.config.poll_interval_ms));
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        let mut previous = {
-            let _guard = self.apply_lock.lock().await;
-            self.capture_clipboard().await.ok().flatten()
+        let interval_poll = if changes.is_some() {
+            poll.max(WATCHER_RECONCILE_INTERVAL)
+        } else {
+            poll
         };
+        let mut interval = tokio::time::interval(interval_poll);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        {
+            let _guard = self.apply_lock.lock().await;
+            let initial = self.capture_clipboard().await.ok().flatten();
+            *self.last_clipboard.lock().await = initial.map(|snapshot| snapshot.fingerprint);
+        }
+        interval.reset();
         loop {
             tokio::select! {
                 () = next_clipboard_change(&mut changes, &mut interval) => {
@@ -134,10 +145,9 @@ impl Daemon {
                             continue;
                         }
                     };
-                    if previous.as_ref().is_some_and(|last| last.fingerprint == snapshot.fingerprint) {
+                    if !self.record_clipboard_fingerprint(snapshot.fingerprint).await {
                         continue;
                     }
-                    previous = Some(snapshot.clone());
                     if self.take_suppressed(snapshot.fingerprint).await {
                         continue;
                     }
@@ -282,6 +292,7 @@ impl Daemon {
         let _guard = self.apply_lock.lock().await;
         match self.apply_clipboard(Arc::clone(&clip)).await {
             Ok(snapshot) => {
+                *self.last_clipboard.lock().await = Some(snapshot.fingerprint);
                 *self.suppressed.lock().await = Some(snapshot.fingerprint);
             }
             Err(error) => warn!(%error, peer = %peer_name, clip = %clip.id, "failed to apply clipboard"),
@@ -332,6 +343,15 @@ impl Daemon {
 
     async fn take_suppressed(&self, fingerprint: [u8; 32]) -> bool {
         self.suppressed.lock().await.take() == Some(fingerprint)
+    }
+
+    async fn record_clipboard_fingerprint(&self, fingerprint: [u8; 32]) -> bool {
+        let mut last = self.last_clipboard.lock().await;
+        if *last == Some(fingerprint) {
+            return false;
+        }
+        *last = Some(fingerprint);
+        true
     }
 
     fn emit(&self, direction: Direction, peer: Option<String>, clip: &Clip) {
@@ -399,7 +419,11 @@ async fn next_clipboard_change(
     interval: &mut tokio::time::Interval,
 ) {
     if let Some(receiver) = changes {
-        if receiver.recv().await.is_some() {
+        let change = tokio::select! {
+            change = receiver.recv() => change,
+            _ = interval.tick() => return,
+        };
+        if change.is_some() {
             return;
         }
         *changes = None;
@@ -1201,6 +1225,30 @@ mod tests {
 
         assert!(daemon.take_suppressed(second_fingerprint).await);
         assert!(!daemon.take_suppressed(first_fingerprint).await);
+    }
+
+    #[tokio::test]
+    async fn remote_apply_refreshes_the_local_change_baseline() {
+        let clipboard = Arc::new(MockClipboard::default());
+        let daemon = Daemon::new(Config::default(), clipboard);
+        let local = Snapshot::new(vec![Representation {
+            item: 0,
+            format: "text/plain".into(),
+            data: b"local".to_vec(),
+        }]);
+        let remote = Arc::new(Clip::new(
+            Uuid::new_v4(),
+            vec![Representation {
+                item: 0,
+                format: "text/plain".into(),
+                data: b"remote".to_vec(),
+            }],
+        ));
+        *daemon.last_clipboard.lock().await = Some(local.fingerprint);
+
+        daemon.receive_clip(remote, "remote", Uuid::new_v4()).await;
+
+        assert!(daemon.record_clipboard_fingerprint(local.fingerprint).await);
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -114,11 +114,14 @@ impl Daemon {
     }
 
     async fn watch_clipboard(self: Arc<Self>, mut shutdown: watch::Receiver<bool>) {
-        let mut previous = self.capture_clipboard().await.ok().flatten();
         let poll = Duration::from_millis(self.config.poll_interval_ms);
         let mut changes = self.clipboard.change_receiver(poll);
         let mut interval = tokio::time::interval(Duration::from_millis(self.config.poll_interval_ms));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut previous = {
+            let _guard = self.apply_lock.lock().await;
+            self.capture_clipboard().await.ok().flatten()
+        };
         loop {
             tokio::select! {
                 () = next_clipboard_change(&mut changes, &mut interval) => {
@@ -703,6 +706,61 @@ mod tests {
         gate: Condvar,
     }
 
+    struct InitialCaptureClipboard {
+        capture_started: StdMutex<Option<oneshot::Sender<()>>>,
+        apply_started: StdMutex<Option<oneshot::Sender<()>>>,
+        released: StdMutex<bool>,
+        gate: Condvar,
+    }
+
+    impl InitialCaptureClipboard {
+        fn new() -> (Arc<Self>, oneshot::Receiver<()>, oneshot::Receiver<()>) {
+            let (capture_started, capture_receiver) = oneshot::channel();
+            let (apply_started, apply_receiver) = oneshot::channel();
+            (
+                Arc::new(Self {
+                    capture_started: StdMutex::new(Some(capture_started)),
+                    apply_started: StdMutex::new(Some(apply_started)),
+                    released: StdMutex::new(false),
+                    gate: Condvar::new(),
+                }),
+                capture_receiver,
+                apply_receiver,
+            )
+        }
+
+        fn release(&self) {
+            *self.released.lock().unwrap() = true;
+            self.gate.notify_all();
+        }
+    }
+
+    impl ClipboardBackend for InitialCaptureClipboard {
+        fn capture(&self) -> Result<Option<Snapshot>> {
+            if let Some(started) = self.capture_started.lock().unwrap().take() {
+                let _ = started.send(());
+            }
+            let released = self.released.lock().unwrap();
+            let (released, _) = self
+                .gate
+                .wait_timeout_while(released, Duration::from_secs(2), |released| !*released)
+                .unwrap();
+            drop(released);
+            Ok(None)
+        }
+
+        fn apply(&self, representations: &[Representation]) -> Result<Snapshot> {
+            if let Some(started) = self.apply_started.lock().unwrap().take() {
+                let _ = started.send(());
+            }
+            Ok(Snapshot::new(representations.to_vec()))
+        }
+
+        fn name(&self) -> &'static str {
+            "initial capture mock"
+        }
+    }
+
     impl BlockingClipboard {
         fn new(operation: BlockingOperation) -> (Arc<Self>, oneshot::Receiver<()>) {
             let (started, receiver) = oneshot::channel();
@@ -1037,6 +1095,51 @@ mod tests {
         assert_status_is_responsive(daemon).await;
 
         clipboard.release();
+        shutdown_tx.send(true).unwrap();
+        watcher.await.unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn initial_capture_is_serialized_with_remote_apply() {
+        let (clipboard, capture_started, apply_started) = InitialCaptureClipboard::new();
+        let daemon = Daemon::new(Config::default(), clipboard.clone());
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let watcher = tokio::spawn(Arc::clone(&daemon).watch_clipboard(shutdown_rx));
+        timeout(Duration::from_millis(500), capture_started)
+            .await
+            .unwrap()
+            .unwrap();
+        let applying_daemon = Arc::clone(&daemon);
+        let applying = tokio::spawn(async move {
+            applying_daemon
+                .receive_clip(
+                    Arc::new(Clip::new(
+                        Uuid::new_v4(),
+                        vec![Representation {
+                            item: 0,
+                            format: "text/plain".into(),
+                            data: b"remote".to_vec(),
+                        }],
+                    )),
+                    "remote",
+                    Uuid::new_v4(),
+                )
+                .await;
+        });
+        let mut apply_started = Box::pin(apply_started);
+
+        assert!(
+            timeout(Duration::from_millis(100), &mut apply_started)
+                .await
+                .is_err()
+        );
+        clipboard.release();
+        timeout(Duration::from_millis(500), &mut apply_started)
+            .await
+            .unwrap()
+            .unwrap();
+
+        applying.await.unwrap();
         shutdown_tx.send(true).unwrap();
         watcher.await.unwrap();
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -22,7 +22,7 @@ use crate::protocol::{Message, read_message, write_clip, write_message};
 use crate::ssh;
 use crate::update::{self, CURRENT_VERSION};
 
-const WATCHER_RECONCILE_INTERVAL: Duration = Duration::from_secs(1);
+const WATCHER_STARTUP_RECONCILE_DELAY: Duration = Duration::from_secs(1);
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PeerStatus {
@@ -120,12 +120,7 @@ impl Daemon {
     async fn watch_clipboard(self: Arc<Self>, mut shutdown: watch::Receiver<bool>) {
         let poll = Duration::from_millis(self.config.poll_interval_ms);
         let mut changes = self.clipboard.change_receiver(poll);
-        let interval_poll = if changes.is_some() {
-            poll.max(WATCHER_RECONCILE_INTERVAL)
-        } else {
-            poll
-        };
-        let mut interval = tokio::time::interval(interval_poll);
+        let mut interval = tokio::time::interval(poll);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         {
             let _guard = self.apply_lock.lock().await;
@@ -133,9 +128,12 @@ impl Daemon {
             *self.last_clipboard.lock().await = initial.map(|snapshot| snapshot.fingerprint);
         }
         interval.reset();
+        let mut startup_reconcile = changes
+            .as_ref()
+            .map(|_| tokio::time::Instant::now() + WATCHER_STARTUP_RECONCILE_DELAY);
         loop {
             tokio::select! {
-                () = next_clipboard_change(&mut changes, &mut interval) => {
+                () = next_clipboard_change(&mut changes, &mut interval, &mut startup_reconcile) => {
                     let _guard = self.apply_lock.lock().await;
                     let snapshot = match self.capture_clipboard().await {
                         Ok(Some(snapshot)) => snapshot,
@@ -414,16 +412,28 @@ impl Daemon {
     }
 }
 
-async fn next_clipboard_change(changes: &mut Option<ChangeReceiver>, interval: &mut tokio::time::Interval) {
+async fn next_clipboard_change(
+    changes: &mut Option<ChangeReceiver>,
+    interval: &mut tokio::time::Interval,
+    startup_reconcile: &mut Option<tokio::time::Instant>,
+) {
     if let Some(receiver) = changes {
-        let change = tokio::select! {
-            change = receiver.recv() => change,
-            _ = interval.tick() => return,
+        let change = if let Some(deadline) = *startup_reconcile {
+            tokio::select! {
+                change = receiver.recv() => change,
+                () = tokio::time::sleep_until(deadline) => {
+                    *startup_reconcile = None;
+                    return;
+                }
+            }
+        } else {
+            receiver.recv().await
         };
         if change.is_some() {
             return;
         }
         *changes = None;
+        interval.reset();
     }
     interval.tick().await;
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -14,7 +14,7 @@ use tokio::task::JoinSet;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
-use crate::clipboard::{ClipboardBackend, NativeClipboard};
+use crate::clipboard::{ClipboardBackend, NativeClipboard, Snapshot};
 use crate::config::{Config, PeerConfig, detected_machine_name, ensure_private_dir, paths};
 use crate::filebundle;
 use crate::model::{Clip, Direction, MonitorEvent};
@@ -114,7 +114,7 @@ impl Daemon {
     }
 
     async fn watch_clipboard(self: Arc<Self>, mut shutdown: watch::Receiver<bool>) {
-        let mut previous = self.clipboard.capture().await.ok().flatten();
+        let mut previous = self.capture_clipboard().await.ok().flatten();
         let poll = Duration::from_millis(self.config.poll_interval_ms);
         let mut changes = self.clipboard.change_receiver(poll);
         let mut interval = tokio::time::interval(Duration::from_millis(self.config.poll_interval_ms));
@@ -123,7 +123,7 @@ impl Daemon {
             tokio::select! {
                 () = next_clipboard_change(&mut changes, &mut interval) => {
                     let _guard = self.apply_lock.lock().await;
-                    let snapshot = match self.clipboard.capture().await {
+                    let snapshot = match self.capture_clipboard().await {
                         Ok(Some(snapshot)) => snapshot,
                         Ok(None) => continue,
                         Err(error) => {
@@ -283,14 +283,7 @@ impl Daemon {
         self.emit(Direction::Receive, Some(peer_name.to_owned()), &clip);
         self.broadcast_clip(Arc::clone(&clip), Some(source)).await;
         let _guard = self.apply_lock.lock().await;
-        let representations = match filebundle::materialize(clip.id, &clip.representations) {
-            Ok(representations) => representations,
-            Err(error) => {
-                warn!(%error, peer = %peer_name, clip = %clip.id, "failed to materialize copied files");
-                return;
-            }
-        };
-        match self.clipboard.apply(&representations).await {
+        match self.apply_clipboard(Arc::clone(&clip)).await {
             Ok(snapshot) => {
                 *self
                     .suppressed
@@ -301,6 +294,24 @@ impl Daemon {
             }
             Err(error) => warn!(%error, peer = %peer_name, clip = %clip.id, "failed to apply clipboard"),
         }
+    }
+
+    async fn capture_clipboard(&self) -> Result<Option<Snapshot>> {
+        let clipboard = Arc::clone(&self.clipboard);
+        tokio::task::spawn_blocking(move || clipboard.capture())
+            .await
+            .context("clipboard capture worker stopped")?
+    }
+
+    async fn apply_clipboard(&self, clip: Arc<Clip>) -> Result<Snapshot> {
+        let clipboard = Arc::clone(&self.clipboard);
+        tokio::task::spawn_blocking(move || {
+            let representations = filebundle::materialize(clip.id, &clip.representations)
+                .context("materialize copied files")?;
+            clipboard.apply(&representations)
+        })
+        .await
+        .context("clipboard apply worker stopped")?
     }
 
     async fn broadcast_clip(&self, clip: Arc<Clip>, except: Option<Uuid>) {
@@ -676,12 +687,96 @@ async fn shutdown_signal() {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Condvar, Mutex as StdMutex};
+
     use tokio::io::{duplex, split};
+    use tokio::sync::oneshot;
     use tokio::time::timeout;
 
     use super::*;
     use crate::clipboard::test_support::MockClipboard;
     use crate::model::Representation;
+
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum BlockingOperation {
+        Capture,
+        Apply,
+    }
+
+    struct BlockingClipboard {
+        operation: BlockingOperation,
+        started: StdMutex<Option<oneshot::Sender<()>>>,
+        released: StdMutex<bool>,
+        gate: Condvar,
+    }
+
+    impl BlockingClipboard {
+        fn new(operation: BlockingOperation) -> (Arc<Self>, oneshot::Receiver<()>) {
+            let (started, receiver) = oneshot::channel();
+            (
+                Arc::new(Self {
+                    operation,
+                    started: StdMutex::new(Some(started)),
+                    released: StdMutex::new(false),
+                    gate: Condvar::new(),
+                }),
+                receiver,
+            )
+        }
+
+        fn block(&self, operation: BlockingOperation) {
+            if self.operation != operation {
+                return;
+            }
+            if let Some(started) = self.started.lock().unwrap().take() {
+                let _ = started.send(());
+            }
+            let released = self.released.lock().unwrap();
+            let (released, _) = self
+                .gate
+                .wait_timeout_while(released, Duration::from_secs(2), |released| !*released)
+                .unwrap();
+            drop(released);
+        }
+
+        fn release(&self) {
+            *self.released.lock().unwrap() = true;
+            self.gate.notify_all();
+        }
+    }
+
+    impl ClipboardBackend for BlockingClipboard {
+        fn capture(&self) -> Result<Option<Snapshot>> {
+            self.block(BlockingOperation::Capture);
+            Ok(None)
+        }
+
+        fn apply(&self, representations: &[Representation]) -> Result<Snapshot> {
+            self.block(BlockingOperation::Apply);
+            Ok(Snapshot::new(representations.to_vec()))
+        }
+
+        fn name(&self) -> &'static str {
+            "blocking mock"
+        }
+    }
+
+    async fn assert_status_is_responsive(daemon: Arc<Daemon>) {
+        let (mut client, server) = UnixStream::pair().unwrap();
+        client.write_all(b"STATUS\n").await.unwrap();
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+        let request = tokio::spawn(handle_local(daemon, server, shutdown_rx));
+        let mut line = String::new();
+        timeout(
+            Duration::from_millis(250),
+            BufReader::new(client).read_line(&mut line),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(serde_json::from_str::<Status>(&line).unwrap().running);
+        request.await.unwrap().unwrap();
+    }
 
     #[test]
     fn status_from_an_older_daemon_defaults_version_fields() {
@@ -920,7 +1015,7 @@ mod tests {
         assert_eq!(relayed, Message::Clip(clip.clone()));
         let applied = timeout(Duration::from_secs(1), async {
             loop {
-                if let Some(snapshot) = clipboard.capture().await.unwrap()
+                if let Some(snapshot) = clipboard.capture().unwrap()
                     && snapshot.representations == clip.representations
                 {
                     break snapshot;
@@ -931,6 +1026,55 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(applied.representations, clip.representations);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn slow_capture_keeps_local_commands_responsive() {
+        let (clipboard, started) = BlockingClipboard::new(BlockingOperation::Capture);
+        let daemon = Daemon::new(Config::default(), clipboard.clone());
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let watcher = tokio::spawn(Arc::clone(&daemon).watch_clipboard(shutdown_rx));
+        let wait_started = Instant::now();
+
+        timeout(Duration::from_millis(500), started)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(wait_started.elapsed() < Duration::from_millis(500));
+        assert_status_is_responsive(daemon).await;
+
+        clipboard.release();
+        shutdown_tx.send(true).unwrap();
+        watcher.await.unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn slow_apply_keeps_local_commands_responsive() {
+        let (clipboard, started) = BlockingClipboard::new(BlockingOperation::Apply);
+        let daemon = Daemon::new(Config::default(), clipboard.clone());
+        let clip = Arc::new(Clip::new(
+            Uuid::new_v4(),
+            vec![Representation {
+                item: 0,
+                format: "text/plain".into(),
+                data: b"responsive".to_vec(),
+            }],
+        ));
+        let applying_daemon = Arc::clone(&daemon);
+        let applying = tokio::spawn(async move {
+            applying_daemon.receive_clip(clip, "remote", Uuid::new_v4()).await;
+        });
+        let wait_started = Instant::now();
+
+        timeout(Duration::from_millis(500), started)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(wait_started.elapsed() < Duration::from_millis(500));
+        assert_status_is_responsive(daemon).await;
+
+        clipboard.release();
+        applying.await.unwrap();
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -256,59 +256,72 @@ impl Daemon {
             established.store(true, Ordering::Release);
         }
 
-        let result = loop {
-            tokio::select! {
-                incoming = read_message(reader, self.config.max_bytes) => {
-                    match incoming {
-                        Ok(Message::Clip(clip)) => self.receive_clip(Arc::new(clip), &node_name, connection_id).await,
-                        Ok(Message::Hello { .. }) => {
-                            break Err(anyhow::anyhow!("peer sent a second hello"));
-                        }
-                        Ok(Message::UpdateAvailable { version, .. }) => {
-                            if let Some(peer) = self.peers.write().await.get_mut(&connection_id) {
-                                peer.desired_version = Some(version.clone());
-                            }
-                            if update::newer_version(CURRENT_VERSION, &version) {
-                                let _ = self.update_hints.send(version);
-                            }
-                        }
-                        Err(error) => break Err(error.into()),
+        let read_loop = async {
+            loop {
+                match read_message(reader, self.config.max_bytes).await {
+                    Ok(Message::Clip(clip)) => {
+                        self.receive_clip(Arc::new(clip), &node_name, connection_id).await;
                     }
+                    Ok(Message::Hello { .. }) => {
+                        break Err(anyhow::anyhow!("peer sent a second hello"));
+                    }
+                    Ok(Message::UpdateAvailable { version, .. }) => {
+                        if let Some(peer) = self.peers.write().await.get_mut(&connection_id) {
+                            peer.desired_version = Some(version.clone());
+                        }
+                        if update::newer_version(CURRENT_VERSION, &version) {
+                            let _ = self.update_hints.send(version);
+                        }
+                    }
+                    Err(error) => break Err(error.into()),
                 }
-                changed = receiver.changed() => {
-                    if changed.is_err() {
-                        break Ok(());
+            }
+        };
+        let write_loop = async {
+            loop {
+                tokio::select! {
+                    changed = receiver.changed() => {
+                        if changed.is_err() {
+                            break Ok(());
+                        }
+                        let clip = receiver.borrow_and_update().clone();
+                        if let Some(clip) = clip {
+                            if let Err(error) = write_clip(writer, &clip, self.config.max_bytes).await {
+                                break Err(error.into());
+                            }
+                            self.emit(Direction::Send, Some(node_name.clone()), &clip);
+                        }
                     }
-                    let clip = receiver.borrow_and_update().clone();
-                    if let Some(clip) = clip {
-                        if let Err(error) = write_clip(writer, &clip, self.config.max_bytes).await {
+                    changed = desired_updates.changed(), if app_version.is_some() => {
+                        if changed.is_err() {
+                            break Ok(());
+                        }
+                        let version = desired_updates.borrow_and_update().clone();
+                        if let Err(error) = write_message(
+                            writer,
+                            &Message::UpdateAvailable {
+                                update_id: Uuid::new_v4(),
+                                version,
+                            },
+                            self.config.max_bytes,
+                        ).await {
                             break Err(error.into());
                         }
-                        self.emit(Direction::Send, Some(node_name.clone()), &clip);
-                    }
-                }
-                changed = desired_updates.changed(), if app_version.is_some() => {
-                    if changed.is_err() {
-                        break Ok(());
-                    }
-                    let version = desired_updates.borrow_and_update().clone();
-                    if let Err(error) = write_message(
-                        writer,
-                        &Message::UpdateAvailable {
-                            update_id: Uuid::new_v4(),
-                            version,
-                        },
-                        self.config.max_bytes,
-                    ).await {
-                        break Err(error.into());
-                    }
-                }
-                changed = shutdown.changed() => {
-                    if changed.is_err() || *shutdown.borrow() {
-                        break Ok(());
                     }
                 }
             }
+        };
+        let shutdown_loop = async {
+            loop {
+                if *shutdown.borrow() || shutdown.changed().await.is_err() {
+                    break;
+                }
+            }
+        };
+        let result = tokio::select! {
+            result = read_loop => result,
+            result = write_loop => result,
+            () = shutdown_loop => Ok(()),
         };
         self.peers.write().await.remove(&connection_id);
         info!(peer = %node_name, "peer disconnected");
@@ -750,10 +763,12 @@ async fn shutdown_signal() {
 
 #[cfg(test)]
 mod tests {
+    use std::pin::Pin;
     use std::sync::{Condvar, Mutex as StdMutex};
+    use std::task::{Context as TaskContext, Poll};
 
     use tokio::io::{duplex, split};
-    use tokio::sync::oneshot;
+    use tokio::sync::{Barrier, oneshot};
     use tokio::time::timeout;
 
     use super::*;
@@ -778,6 +793,65 @@ mod tests {
         apply_started: StdMutex<Option<oneshot::Sender<()>>>,
         released: StdMutex<bool>,
         gate: Condvar,
+    }
+
+    struct GatedWriter<W> {
+        inner: W,
+        armed: Arc<AtomicBool>,
+        gate: Arc<Barrier>,
+        waiting: Option<Pin<Box<dyn Future<Output = ()> + Send>>>,
+        released: bool,
+    }
+
+    impl<W> GatedWriter<W> {
+        fn new(inner: W, armed: Arc<AtomicBool>, gate: Arc<Barrier>) -> Self {
+            Self {
+                inner,
+                armed,
+                gate,
+                waiting: None,
+                released: false,
+            }
+        }
+    }
+
+    impl<W> AsyncWrite for GatedWriter<W>
+    where
+        W: AsyncWrite + Unpin,
+    {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            context: &mut TaskContext<'_>,
+            buffer: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            let this = self.get_mut();
+            if this.armed.load(Ordering::Acquire) && !this.released {
+                if this.waiting.is_none() {
+                    let gate = Arc::clone(&this.gate);
+                    this.waiting = Some(Box::pin(async move {
+                        gate.wait().await;
+                    }));
+                }
+                if this
+                    .waiting
+                    .as_mut()
+                    .is_some_and(|waiting| waiting.as_mut().poll(context).is_pending())
+                {
+                    return Poll::Pending;
+                }
+                this.waiting = None;
+                this.released = true;
+            }
+            Pin::new(&mut this.inner).poll_write(context, buffer)
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, context: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_flush(context)
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, context: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_shutdown(context)
+        }
     }
 
     impl InitialCaptureClipboard {
@@ -1144,6 +1218,111 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(applied.representations, clip.representations);
+    }
+
+    #[tokio::test]
+    async fn simultaneous_large_peer_writes_keep_readers_active() {
+        let left_config = Config {
+            node_name: "left".into(),
+            ..Config::default()
+        };
+        let right_config = Config {
+            node_name: "right".into(),
+            ..Config::default()
+        };
+        let left_clipboard = Arc::new(MockClipboard::default());
+        let right_clipboard = Arc::new(MockClipboard::default());
+        let left_daemon = Daemon::new(left_config.clone(), left_clipboard.clone());
+        let right_daemon = Daemon::new(right_config.clone(), right_clipboard.clone());
+        let (left_stream, right_stream) = duplex(1024);
+        let (mut left_reader, left_writer) = split(left_stream);
+        let (mut right_reader, right_writer) = split(right_stream);
+        let armed = Arc::new(AtomicBool::new(false));
+        let gate = Arc::new(Barrier::new(2));
+        let mut left_writer = GatedWriter::new(left_writer, Arc::clone(&armed), Arc::clone(&gate));
+        let mut right_writer = GatedWriter::new(right_writer, Arc::clone(&armed), Arc::clone(&gate));
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let left_session = {
+            let daemon = Arc::clone(&left_daemon);
+            let shutdown = shutdown_rx.clone();
+            tokio::spawn(async move {
+                daemon
+                    .serve_peer(&mut left_reader, &mut left_writer, "right", shutdown, None)
+                    .await
+            })
+        };
+        let right_session = {
+            let daemon = Arc::clone(&right_daemon);
+            tokio::spawn(async move {
+                daemon
+                    .serve_peer(&mut right_reader, &mut right_writer, "left", shutdown_rx, None)
+                    .await
+            })
+        };
+
+        timeout(Duration::from_secs(1), async {
+            loop {
+                let left_connected = left_daemon.status().await.connected_peers == ["right"];
+                let right_connected = right_daemon.status().await.connected_peers == ["left"];
+                if left_connected && right_connected {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        let left_clip = Arc::new(Clip::new(
+            left_config.node_id,
+            vec![Representation {
+                item: 0,
+                format: "application/octet-stream".into(),
+                data: vec![0x11; 64 * 1024],
+            }],
+        ));
+        let right_clip = Arc::new(Clip::new(
+            right_config.node_id,
+            vec![Representation {
+                item: 0,
+                format: "application/octet-stream".into(),
+                data: vec![0x22; 64 * 1024],
+            }],
+        ));
+        let expected_left = right_clip.representations.clone();
+        let expected_right = left_clip.representations.clone();
+        armed.store(true, Ordering::Release);
+        tokio::join!(
+            left_daemon.broadcast_clip(left_clip, None),
+            right_daemon.broadcast_clip(right_clip, None)
+        );
+
+        timeout(Duration::from_secs(2), async {
+            loop {
+                let left_applied = left_clipboard
+                    .capture()
+                    .unwrap()
+                    .is_some_and(|snapshot| snapshot.representations == expected_left);
+                let right_applied = right_clipboard
+                    .capture()
+                    .unwrap()
+                    .is_some_and(|snapshot| snapshot.representations == expected_right);
+                if left_applied && right_applied {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        shutdown_tx.send(true).unwrap();
+        timeout(Duration::from_secs(1), async {
+            let _ = left_session.await.unwrap();
+            let _ = right_session.await.unwrap();
+        })
+        .await
+        .unwrap();
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -256,9 +256,23 @@ impl Daemon {
             established.store(true, Ordering::Release);
         }
 
+        let (read_stop, mut read_stop_rx) = watch::channel(false);
         let read_loop = async {
             loop {
-                match read_message(reader, self.config.max_bytes).await {
+                if *read_stop_rx.borrow() {
+                    break Ok(());
+                }
+                let incoming = tokio::select! {
+                    biased;
+                    changed = read_stop_rx.changed() => {
+                        if changed.is_err() || *read_stop_rx.borrow() {
+                            break Ok(());
+                        }
+                        continue;
+                    }
+                    incoming = read_message(reader, self.config.max_bytes) => incoming,
+                };
+                match incoming {
                     Ok(Message::Clip(clip)) => {
                         self.receive_clip(Arc::new(clip), &node_name, connection_id).await;
                     }
@@ -318,10 +332,20 @@ impl Daemon {
                 }
             }
         };
+        tokio::pin!(read_loop);
+        tokio::pin!(write_loop);
+        tokio::pin!(shutdown_loop);
         let result = tokio::select! {
-            result = read_loop => result,
-            result = write_loop => result,
-            () = shutdown_loop => Ok(()),
+            result = &mut read_loop => result,
+            result = &mut write_loop => {
+                read_stop.send_replace(true);
+                result.and(read_loop.await)
+            },
+            () = &mut shutdown_loop => {
+                read_stop.send_replace(true);
+                let _ = read_loop.await;
+                Ok(())
+            },
         };
         self.peers.write().await.remove(&connection_id);
         info!(peer = %node_name, "peer disconnected");
@@ -803,6 +827,12 @@ mod tests {
         released: bool,
     }
 
+    struct FailingWriter<W> {
+        inner: W,
+        armed: Arc<AtomicBool>,
+        failed: Option<oneshot::Sender<()>>,
+    }
+
     impl<W> GatedWriter<W> {
         fn new(inner: W, armed: Arc<AtomicBool>, gate: Arc<Barrier>) -> Self {
             Self {
@@ -811,6 +841,16 @@ mod tests {
                 gate,
                 waiting: None,
                 released: false,
+            }
+        }
+    }
+
+    impl<W> FailingWriter<W> {
+        fn new(inner: W, armed: Arc<AtomicBool>, failed: oneshot::Sender<()>) -> Self {
+            Self {
+                inner,
+                armed,
+                failed: Some(failed),
             }
         }
     }
@@ -841,6 +881,34 @@ mod tests {
                 }
                 this.waiting = None;
                 this.released = true;
+            }
+            Pin::new(&mut this.inner).poll_write(context, buffer)
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, context: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_flush(context)
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, context: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_shutdown(context)
+        }
+    }
+
+    impl<W> AsyncWrite for FailingWriter<W>
+    where
+        W: AsyncWrite + Unpin,
+    {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            context: &mut TaskContext<'_>,
+            buffer: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            let this = self.get_mut();
+            if this.armed.load(Ordering::Acquire) {
+                if let Some(failed) = this.failed.take() {
+                    let _ = failed.send(());
+                }
+                return Poll::Ready(Err(std::io::ErrorKind::BrokenPipe.into()));
             }
             Pin::new(&mut this.inner).poll_write(context, buffer)
         }
@@ -1323,6 +1391,102 @@ mod tests {
         })
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn writer_failure_waits_for_active_clipboard_apply() {
+        let config = Config {
+            node_name: "local".into(),
+            ..Config::default()
+        };
+        let (clipboard, apply_started) = BlockingClipboard::new(BlockingOperation::Apply);
+        let daemon = Daemon::new(config.clone(), clipboard.clone());
+        let (peer, server) = duplex(16 * 1024);
+        let (mut peer_reader, mut peer_writer) = split(peer);
+        let (mut server_reader, server_writer) = split(server);
+        let armed = Arc::new(AtomicBool::new(false));
+        let (failed_tx, failed_rx) = oneshot::channel();
+        let mut server_writer = FailingWriter::new(server_writer, Arc::clone(&armed), failed_tx);
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+        let serving_daemon = Arc::clone(&daemon);
+        let mut session = tokio::spawn(async move {
+            serving_daemon
+                .serve_peer(
+                    &mut server_reader,
+                    &mut server_writer,
+                    "remote",
+                    shutdown_rx,
+                    None,
+                )
+                .await
+        });
+        assert!(matches!(
+            read_message(&mut peer_reader, config.max_bytes).await.unwrap(),
+            Message::Hello { .. }
+        ));
+        write_message(
+            &mut peer_writer,
+            &Message::Hello {
+                node_id: Uuid::new_v4(),
+                node_name: "remote".into(),
+                machine_name: Some("remote.local".into()),
+                app_version: Some(CURRENT_VERSION.into()),
+                desired_version: Some(CURRENT_VERSION.into()),
+            },
+            config.max_bytes,
+        )
+        .await
+        .unwrap();
+        let remote_clip = Clip::new(
+            Uuid::new_v4(),
+            vec![Representation {
+                item: 0,
+                format: "text/plain".into(),
+                data: b"remote".to_vec(),
+            }],
+        );
+        let expected = Snapshot::new(remote_clip.representations.clone()).fingerprint;
+        write_clip(&mut peer_writer, &remote_clip, config.max_bytes)
+            .await
+            .unwrap();
+        timeout(Duration::from_millis(500), apply_started)
+            .await
+            .unwrap()
+            .unwrap();
+
+        armed.store(true, Ordering::Release);
+        daemon
+            .broadcast_clip(
+                Arc::new(Clip::new(
+                    config.node_id,
+                    vec![Representation {
+                        item: 0,
+                        format: "text/plain".into(),
+                        data: b"local".to_vec(),
+                    }],
+                )),
+                None,
+            )
+            .await;
+        timeout(Duration::from_millis(500), failed_rx)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(timeout(Duration::from_millis(100), &mut session).await.is_err());
+        assert!(daemon.apply_lock.try_lock().is_err());
+        assert_eq!(*daemon.last_clipboard.lock().await, None);
+        assert_eq!(*daemon.suppressed.lock().await, None);
+
+        clipboard.release();
+        let result = timeout(Duration::from_millis(500), &mut session)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(result.is_err());
+        assert_eq!(*daemon.last_clipboard.lock().await, Some(expected));
+        assert_eq!(*daemon.suppressed.lock().await, Some(expected));
+        assert!(daemon.apply_lock.try_lock().is_ok());
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -77,7 +77,7 @@ struct Daemon {
     clipboard: Arc<dyn ClipboardBackend>,
     peers: RwLock<HashMap<Uuid, PeerLink>>,
     seen: Mutex<HashMap<Uuid, Instant>>,
-    suppressed: Mutex<HashMap<[u8; 32], usize>>,
+    suppressed: Mutex<Option<[u8; 32]>>,
     apply_lock: Mutex<()>,
     events: broadcast::Sender<MonitorEvent>,
     desired_version: watch::Sender<String>,
@@ -105,7 +105,7 @@ impl Daemon {
             clipboard,
             peers: RwLock::new(HashMap::new()),
             seen: Mutex::new(HashMap::new()),
-            suppressed: Mutex::new(HashMap::new()),
+            suppressed: Mutex::new(None),
             apply_lock: Mutex::new(()),
             events,
             desired_version,
@@ -135,15 +135,9 @@ impl Daemon {
                         continue;
                     }
                     previous = Some(snapshot.clone());
-                    let mut suppressed = self.suppressed.lock().await;
-                    if let Some(count) = suppressed.get_mut(&snapshot.fingerprint) {
-                        *count -= 1;
-                        if *count == 0 {
-                            suppressed.remove(&snapshot.fingerprint);
-                        }
+                    if self.take_suppressed(snapshot.fingerprint).await {
                         continue;
                     }
-                    drop(suppressed);
                     let clip = Arc::new(Clip::new(self.config.node_id, snapshot.representations));
                     self.mark_seen(clip.id).await;
                     self.emit(Direction::Local, None, &clip);
@@ -285,12 +279,7 @@ impl Daemon {
         let _guard = self.apply_lock.lock().await;
         match self.apply_clipboard(Arc::clone(&clip)).await {
             Ok(snapshot) => {
-                *self
-                    .suppressed
-                    .lock()
-                    .await
-                    .entry(snapshot.fingerprint)
-                    .or_default() += 1;
+                *self.suppressed.lock().await = Some(snapshot.fingerprint);
             }
             Err(error) => warn!(%error, peer = %peer_name, clip = %clip.id, "failed to apply clipboard"),
         }
@@ -336,6 +325,10 @@ impl Daemon {
             seen.retain(|_, instant| *instant >= cutoff);
         }
         true
+    }
+
+    async fn take_suppressed(&self, fingerprint: [u8; 32]) -> bool {
+        self.suppressed.lock().await.take() == Some(fingerprint)
     }
 
     fn emit(&self, direction: Direction, peer: Option<String>, clip: &Clip) {
@@ -1075,6 +1068,36 @@ mod tests {
 
         clipboard.release();
         applying.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn only_the_latest_remote_fingerprint_is_suppressed() {
+        let clipboard = Arc::new(MockClipboard::default());
+        let daemon = Daemon::new(Config::default(), clipboard);
+        let first = Arc::new(Clip::new(
+            Uuid::new_v4(),
+            vec![Representation {
+                item: 0,
+                format: "text/plain".into(),
+                data: b"first".to_vec(),
+            }],
+        ));
+        let second = Arc::new(Clip::new(
+            Uuid::new_v4(),
+            vec![Representation {
+                item: 0,
+                format: "text/plain".into(),
+                data: b"second".to_vec(),
+            }],
+        ));
+        let first_fingerprint = Snapshot::new(first.representations.clone()).fingerprint;
+        let second_fingerprint = Snapshot::new(second.representations.clone()).fingerprint;
+
+        daemon.receive_clip(first, "remote", Uuid::new_v4()).await;
+        daemon.receive_clip(second, "remote", Uuid::new_v4()).await;
+
+        assert!(daemon.take_suppressed(second_fingerprint).await);
+        assert!(!daemon.take_suppressed(first_fingerprint).await);
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -22,7 +22,35 @@ use crate::protocol::{Message, read_message, write_clip, write_message};
 use crate::ssh;
 use crate::update::{self, CURRENT_VERSION};
 
-const WATCHER_STARTUP_RECONCILE_DELAY: Duration = Duration::from_secs(1);
+const WATCHER_RECONCILE_INITIAL_DELAY: Duration = Duration::from_secs(1);
+const WATCHER_RECONCILE_MAX_DELAY: Duration = Duration::from_secs(30);
+
+#[derive(Clone, Copy)]
+struct WatcherReconcile {
+    deadline: tokio::time::Instant,
+    delay: Duration,
+}
+
+impl WatcherReconcile {
+    fn new(now: tokio::time::Instant) -> Self {
+        Self {
+            deadline: now + WATCHER_RECONCILE_INITIAL_DELAY,
+            delay: WATCHER_RECONCILE_INITIAL_DELAY,
+        }
+    }
+
+    fn retry(&mut self, now: tokio::time::Instant) {
+        self.delay = self.delay.saturating_mul(2).min(WATCHER_RECONCILE_MAX_DELAY);
+        self.deadline = now + self.delay;
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ClipboardWake {
+    Native,
+    Reconcile,
+    Poll,
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PeerStatus {
@@ -128,14 +156,20 @@ impl Daemon {
             *self.last_clipboard.lock().await = initial.map(|snapshot| snapshot.fingerprint);
         }
         interval.reset();
-        let mut startup_reconcile = changes
+        let mut watcher_reconcile = changes
             .as_ref()
-            .map(|_| tokio::time::Instant::now() + WATCHER_STARTUP_RECONCILE_DELAY);
+            .map(|_| WatcherReconcile::new(tokio::time::Instant::now()));
         loop {
             tokio::select! {
-                () = next_clipboard_change(&mut changes, &mut interval, &mut startup_reconcile) => {
+                wake = next_clipboard_change(&mut changes, &mut interval, &mut watcher_reconcile) => {
                     let _guard = self.apply_lock.lock().await;
-                    let snapshot = match self.capture_clipboard().await {
+                    let snapshot = self.capture_clipboard().await;
+                    if wake == ClipboardWake::Reconcile
+                        && let Some(reconcile) = &mut watcher_reconcile
+                    {
+                        reconcile.retry(tokio::time::Instant::now());
+                    }
+                    let snapshot = match snapshot {
                         Ok(Some(snapshot)) => snapshot,
                         Ok(None) => continue,
                         Err(error) => {
@@ -415,27 +449,29 @@ impl Daemon {
 async fn next_clipboard_change(
     changes: &mut Option<ChangeReceiver>,
     interval: &mut tokio::time::Interval,
-    startup_reconcile: &mut Option<tokio::time::Instant>,
-) {
+    watcher_reconcile: &mut Option<WatcherReconcile>,
+) -> ClipboardWake {
     if let Some(receiver) = changes {
-        let change = if let Some(deadline) = *startup_reconcile {
+        let change = if let Some(reconcile) = watcher_reconcile.as_ref() {
             tokio::select! {
                 change = receiver.recv() => change,
-                () = tokio::time::sleep_until(deadline) => {
-                    *startup_reconcile = None;
-                    return;
+                () = tokio::time::sleep_until(reconcile.deadline) => {
+                    return ClipboardWake::Reconcile;
                 }
             }
         } else {
             receiver.recv().await
         };
         if change.is_some() {
-            return;
+            *watcher_reconcile = None;
+            return ClipboardWake::Native;
         }
         *changes = None;
+        *watcher_reconcile = None;
         interval.reset();
     }
     interval.tick().await;
+    ClipboardWake::Poll
 }
 
 pub async fn run(config: Config) -> Result<()> {
@@ -1256,6 +1292,66 @@ mod tests {
         daemon.receive_clip(remote, "remote", Uuid::new_v4()).await;
 
         assert!(daemon.record_clipboard_fingerprint(local.fingerprint).await);
+    }
+
+    #[test]
+    fn watcher_reconciliation_retries_with_bounded_backoff() {
+        let mut now = tokio::time::Instant::now();
+        let mut reconcile = WatcherReconcile::new(now);
+        assert_eq!(reconcile.deadline.duration_since(now), Duration::from_secs(1));
+
+        for expected in [2, 4, 8, 16, 30, 30] {
+            now = reconcile.deadline;
+            reconcile.retry(now);
+            assert_eq!(reconcile.delay, Duration::from_secs(expected));
+            assert_eq!(
+                reconcile.deadline.duration_since(now),
+                Duration::from_secs(expected)
+            );
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn watcher_reconciliation_continues_until_native_event() {
+        let (sender, receiver) = mpsc::channel(1);
+        let mut changes = Some(ChangeReceiver::for_test(receiver));
+        let mut interval = tokio::time::interval(Duration::from_secs(60));
+        let mut reconcile = Some(WatcherReconcile::new(tokio::time::Instant::now()));
+
+        assert_eq!(
+            next_clipboard_change(&mut changes, &mut interval, &mut reconcile).await,
+            ClipboardWake::Reconcile
+        );
+        tokio::time::advance(Duration::from_secs(5)).await;
+        reconcile.as_mut().unwrap().retry(tokio::time::Instant::now());
+        assert_eq!(
+            reconcile
+                .as_ref()
+                .unwrap()
+                .deadline
+                .duration_since(tokio::time::Instant::now()),
+            Duration::from_secs(2)
+        );
+
+        assert_eq!(
+            next_clipboard_change(&mut changes, &mut interval, &mut reconcile).await,
+            ClipboardWake::Reconcile
+        );
+        reconcile.as_mut().unwrap().retry(tokio::time::Instant::now());
+        sender.try_send(()).unwrap();
+        assert_eq!(
+            next_clipboard_change(&mut changes, &mut interval, &mut reconcile).await,
+            ClipboardWake::Native
+        );
+        assert!(reconcile.is_none());
+        assert!(
+            timeout(
+                Duration::from_secs(31),
+                next_clipboard_change(&mut changes, &mut interval, &mut reconcile)
+            )
+            .await
+            .is_err()
+        );
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -14,7 +14,7 @@ use tokio::task::JoinSet;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
-use crate::clipboard::{ClipboardBackend, NativeClipboard, Snapshot};
+use crate::clipboard::{ChangeReceiver, ClipboardBackend, NativeClipboard, Snapshot};
 use crate::config::{Config, PeerConfig, detected_machine_name, ensure_private_dir, paths};
 use crate::filebundle;
 use crate::model::{Clip, Direction, MonitorEvent};
@@ -414,10 +414,7 @@ impl Daemon {
     }
 }
 
-async fn next_clipboard_change(
-    changes: &mut Option<tokio::sync::mpsc::Receiver<()>>,
-    interval: &mut tokio::time::Interval,
-) {
+async fn next_clipboard_change(changes: &mut Option<ChangeReceiver>, interval: &mut tokio::time::Interval) {
     if let Some(receiver) = changes {
         let change = tokio::select! {
             change = receiver.recv() => change,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -399,7 +399,7 @@ impl Daemon {
 }
 
 async fn next_clipboard_change(
-    changes: &mut Option<tokio::sync::mpsc::UnboundedReceiver<()>>,
+    changes: &mut Option<tokio::sync::mpsc::Receiver<()>>,
     interval: &mut tokio::time::Interval,
 ) {
     if let Some(receiver) = changes {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
@@ -7,6 +8,8 @@ use ssh_clipboard::daemon;
 use ssh_clipboard::model::{Direction, MonitorEvent, human_bytes};
 use ssh_clipboard::{deploy, service, tui, update};
 use tokio::io::AsyncBufReadExt;
+
+const RUNTIME_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[derive(Parser)]
 #[command(
@@ -68,12 +71,24 @@ enum ServiceAction {
     Restart,
 }
 
-#[tokio::main]
-async fn main() {
-    if let Err(error) = run().await {
+fn main() {
+    let runtime = match tokio::runtime::Builder::new_multi_thread().enable_all().build() {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            eprintln!("ssh-clipboard: initialize async runtime: {error}");
+            std::process::exit(1);
+        }
+    };
+    let result = runtime.block_on(run());
+    shutdown_runtime(runtime);
+    if let Err(error) = result {
         eprintln!("ssh-clipboard: {error:#}");
         std::process::exit(1);
     }
+}
+
+fn shutdown_runtime(runtime: tokio::runtime::Runtime) {
+    runtime.shutdown_timeout(RUNTIME_SHUTDOWN_TIMEOUT);
 }
 
 async fn run() -> Result<()> {
@@ -223,4 +238,36 @@ fn format_time(timestamp_millis: u64) -> String {
         (day / 1_000) % 60,
         day % 1_000
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc;
+    use std::time::Instant;
+
+    use super::*;
+
+    #[test]
+    fn runtime_shutdown_is_bounded_when_blocking_work_hangs() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let (started_tx, started_rx) = mpsc::sync_channel(0);
+        let (release_tx, release_rx) = mpsc::channel();
+        let (finished_tx, finished_rx) = mpsc::sync_channel(0);
+        let _task = runtime.handle().spawn_blocking(move || {
+            started_tx.send(()).unwrap();
+            let _ = release_rx.recv();
+            finished_tx.send(()).unwrap();
+        });
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        let started = Instant::now();
+
+        shutdown_runtime(runtime);
+
+        assert!(started.elapsed() < Duration::from_millis(1_500));
+        release_tx.send(()).unwrap();
+        finished_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+    }
 }


### PR DESCRIPTION
Keep clipboard synchronization responsive during slow native I/O and backpressured transfers while normalizing macOS and Linux clipboard formats.