### PR TITLE
Fix Linux clipboard images on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,6 +1578,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7902ac02859fc1f7045f8b598c63f1ae0cc7efeaa06a9bc9f3d9a3c955974fa4"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-user-notifications"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,6 +2443,7 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "objc2-uniform-type-identifiers",
  "percent-encoding",
  "pretty_assertions",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ clipboard-rs = { version = "0.3.5", default-features = false, features = ["image
 objc2 = "0.6.3"
 objc2-app-kit = { version = "0.3.2", features = ["NSPasteboard", "NSPasteboardItem"] }
 objc2-foundation = { version = "0.3.2", features = ["NSArray", "NSData", "NSString"] }
+objc2-uniform-type-identifiers = { version = "0.3.2", default-features = false, features = ["UTType"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 clipboard-rs = { version = "0.3.5", default-features = false, features = ["wayland"] }

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -223,6 +223,7 @@ impl NativeClipboard {
             contents.push(ClipboardContent::Files(native_files));
         } else {
             let mut added_files = false;
+            let mut added_formats = HashSet::new();
             for representation in representations {
                 if representation.format.trim().is_empty()
                     || is_internal_marker(&representation.format)
@@ -235,10 +236,17 @@ impl NativeClipboard {
                     added_files = true;
                     continue;
                 }
-                contents.push(ClipboardContent::Other(
-                    representation.format.clone(),
-                    representation.data.clone(),
-                ));
+
+                #[cfg(target_os = "macos")]
+                let Some(format) = macos::native_pasteboard_format(&representation.format) else {
+                    continue;
+                };
+                #[cfg(not(target_os = "macos"))]
+                let format = representation.format.clone();
+                if !added_formats.insert(format.clone()) {
+                    continue;
+                }
+                contents.push(ClipboardContent::Other(format, representation.data.clone()));
             }
         }
         if contents.is_empty() {

--- a/src/clipboard/macos.rs
+++ b/src/clipboard/macos.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result, bail};
 use objc2::runtime::ProtocolObject;
 use objc2_app_kit::{NSPasteboard, NSPasteboardItem};
 use objc2_foundation::{NSArray, NSData, NSString};
+use objc2_uniform_type_identifiers::UTType;
 
 use crate::filebundle;
 use crate::model::Representation;
@@ -43,10 +44,10 @@ fn publish_single_file_to(
         let Some(format) = native_image_format(&representation.format) else {
             continue;
         };
-        if !image_types.insert(format) {
+        if !image_types.insert(format.clone()) {
             continue;
         }
-        set_data(&item, format, &representation.data)?;
+        set_data(&item, &format, &representation.data)?;
     }
 
     if image_types.is_empty() {
@@ -72,17 +73,60 @@ fn set_data(item: &NSPasteboardItem, format: &str, bytes: &[u8]) -> Result<()> {
     Ok(())
 }
 
-fn native_image_format(format: &str) -> Option<&'static str> {
+pub(super) fn native_pasteboard_format(format: &str) -> Option<String> {
     match format {
-        "public.png" | "image/png" => Some("public.png"),
-        "public.jpeg" | "image/jpeg" | "image/jpg" => Some("public.jpeg"),
-        "public.tiff" | "image/tiff" => Some("public.tiff"),
-        "com.compuserve.gif" | "image/gif" => Some("com.compuserve.gif"),
-        "public.heic" | "image/heic" => Some("public.heic"),
-        "public.heif" | "image/heif" => Some("public.heif"),
-        "org.webmproject.webp" | "image/webp" => Some("org.webmproject.webp"),
-        _ => None,
+        "NSStringPboardType" | "STRING" | "TEXT" | "UTF8_STRING" => {
+            return Some("public.utf8-plain-text".to_owned());
+        }
+        "NSHTMLPboardType" => return Some("public.html".to_owned()),
+        "NSRTFPboardType" => return Some("public.rtf".to_owned()),
+        "NSTIFFPboardType" => return Some("public.tiff".to_owned()),
+        _ => {}
     }
+
+    if !format.contains('/') {
+        return is_valid_uti(format).then(|| format.to_owned());
+    }
+    let mime_type = format
+        .split_once(';')
+        .map_or(format, |(mime_type, _)| mime_type)
+        .trim();
+    let (type_name, subtype) = mime_type.split_once('/')?;
+    if type_name.is_empty() || subtype.is_empty() {
+        return None;
+    }
+    if mime_type.eq_ignore_ascii_case("text/plain")
+        && format.split(';').skip(1).map(str::trim).any(|parameter| {
+            parameter.eq_ignore_ascii_case("charset=utf-8") || parameter.eq_ignore_ascii_case("charset=utf8")
+        })
+    {
+        return Some("public.utf8-plain-text".to_owned());
+    }
+    UTType::typeWithMIMEType(&NSString::from_str(mime_type))
+        .map(|native_type| native_type.identifier().to_string())
+}
+
+fn is_valid_uti(format: &str) -> bool {
+    format.contains('.')
+        && format
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-'))
+}
+
+fn native_image_format(format: &str) -> Option<String> {
+    let native_type = if format.contains('/') {
+        let mime_type = format
+            .split_once(';')
+            .map_or(format, |(mime_type, _)| mime_type)
+            .trim();
+        UTType::typeWithMIMEType(&NSString::from_str(mime_type))?
+    } else {
+        UTType::typeWithIdentifier(&NSString::from_str(format))?
+    };
+    let image_type = UTType::typeWithIdentifier(&NSString::from_str("public.image"))?;
+    native_type
+        .conformsToType(&image_type)
+        .then(|| native_type.identifier().to_string())
 }
 
 fn detect_image_format(path: &Path, bytes: &[u8]) -> Option<&'static str> {
@@ -170,6 +214,84 @@ mod tests {
         assert_eq!(
             detect_image_format(Path::new("attachment.webp"), b"not enough bytes"),
             Some("org.webmproject.webp")
+        );
+    }
+
+    #[test]
+    fn resolves_portable_mime_types_to_macos_pasteboard_types() {
+        assert_eq!(
+            native_pasteboard_format("image/png").as_deref(),
+            Some("public.png")
+        );
+        assert_eq!(
+            native_pasteboard_format("text/html; charset=utf-8").as_deref(),
+            Some("public.html")
+        );
+        assert_eq!(
+            native_pasteboard_format("text/plain;charset=utf-8").as_deref(),
+            Some("public.utf8-plain-text")
+        );
+        assert_eq!(
+            native_pasteboard_format("UTF8_STRING").as_deref(),
+            Some("public.utf8-plain-text")
+        );
+        assert_eq!(
+            native_pasteboard_format("public.png").as_deref(),
+            Some("public.png")
+        );
+        assert_eq!(
+            native_pasteboard_format("com.example.custom-data").as_deref(),
+            Some("com.example.custom-data")
+        );
+        assert_eq!(native_pasteboard_format("INVALID_ATOM"), None);
+
+        let custom = native_pasteboard_format("chromium/x-web-custom-data").unwrap();
+        assert!(!custom.contains('/'));
+        assert!(UTType::typeWithIdentifier(&NSString::from_str(&custom)).is_some());
+    }
+
+    #[test]
+    fn publishes_a_portable_mime_image_as_a_macos_image_type() {
+        let pasteboard = NSPasteboard::pasteboardWithUniqueName();
+        let item = NSPasteboardItem::new();
+        let png = b"\x89PNG\r\n\x1a\nfixture";
+        let format = native_pasteboard_format("image/png").unwrap();
+        set_data(&item, &format, png).unwrap();
+
+        pasteboard.clearContents();
+        let objects = NSArray::from_retained_slice(&[ProtocolObject::from_retained(item)]);
+        assert!(pasteboard.writeObjects(&objects));
+        assert_eq!(
+            pasteboard
+                .dataForType(&NSString::from_str("public.png"))
+                .unwrap()
+                .to_vec(),
+            png
+        );
+    }
+
+    #[test]
+    fn publishes_utf8_mime_text_as_macos_pasteboard_text() {
+        let pasteboard = NSPasteboard::pasteboardWithUniqueName();
+        let item = NSPasteboardItem::new();
+        let text = "portable text";
+        let format = native_pasteboard_format("text/plain;charset=utf-8").unwrap();
+        set_data(&item, &format, text.as_bytes()).unwrap();
+
+        pasteboard.clearContents();
+        let objects = NSArray::from_retained_slice(&[ProtocolObject::from_retained(item)]);
+        assert!(pasteboard.writeObjects(&objects));
+        assert_eq!(
+            pasteboard
+                .pasteboardItems()
+                .unwrap()
+                .iter()
+                .next()
+                .unwrap()
+                .stringForType(&NSString::from_str("public.utf8-plain-text"))
+                .unwrap()
+                .to_string(),
+            text
         );
     }
 }


### PR DESCRIPTION
Linux clipboard formats arrive as MIME types, but NSPasteboard expects UTIs. That caused PNG payloads to disappear on macOS and made some Wayland text aliases invalid.

This resolves MIME types through UTType at the macOS boundary, maps the common text atoms, and deduplicates aliases before publishing.

Tested with Nautilus PNG → Preview and Paste, plus `cargo test --all-targets`.