### PR TITLE
Map portable MIME names onto macOS pasteboard types

### DIFF
--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -243,7 +243,7 @@ impl NativeClipboard {
                     // refused type is enough to leave the whole item empty, so map the
                     // portable MIME names a Linux peer sends back to pasteboard types
                     // and drop anything that has no equivalent.
-                    let Some(native) = native_pasteboard_type(&representation.format) else {
+                    let Some(native) = macos::native_pasteboard_type(&representation.format) else {
                         continue;
                     };
                     if !published.insert(native.clone()) {
@@ -406,51 +406,6 @@ fn clipboard_file_paths(representations: &[Representation]) -> Vec<String> {
         .collect()
 }
 
-/// Maps a portable MIME name onto the macOS pasteboard type carrying the same
-/// bytes. `add_portable_aliases` is the outbound half of this pairing; without
-/// the inbound half every representation from a Wayland or X11 peer reaches
-/// NSPasteboard as an invalid UTI and the publish clears the pasteboard.
-#[cfg(target_os = "macos")]
-fn native_pasteboard_type(format: &str) -> Option<String> {
-    if is_pasteboard_type(format) {
-        return Some(format.to_owned());
-    }
-    // MIME names carry parameters such as `text/plain;charset=utf-8`.
-    let base = format
-        .split(';')
-        .next()
-        .unwrap_or(format)
-        .trim()
-        .to_ascii_lowercase();
-    let native = match base.as_str() {
-        "text/plain" | "text" | "string" | "utf8_string" => "public.utf8-plain-text",
-        "text/html" => "public.html",
-        "text/rtf" | "application/rtf" => "public.rtf",
-        "image/png" => "public.png",
-        "image/jpeg" | "image/jpg" => "public.jpeg",
-        "image/tiff" => "public.tiff",
-        "image/gif" => "com.compuserve.gif",
-        "image/heic" => "public.heic",
-        "image/heif" => "public.heif",
-        "image/webp" => "org.webmproject.webp",
-        "application/pdf" => "com.adobe.pdf",
-        "text/uri-list" => "public.file-url",
-        _ => return None,
-    };
-    Some(native.to_owned())
-}
-
-/// Recognizes the reverse-DNS UTIs a macOS peer sends, which pass through
-/// unchanged.
-#[cfg(target_os = "macos")]
-fn is_pasteboard_type(format: &str) -> bool {
-    format.contains('.')
-        && !format.contains('/')
-        && format
-            .chars()
-            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '+' | '_'))
-}
-
 fn add_portable_aliases(representations: &mut Vec<Representation>, mut remaining: u64) {
     let originals = representations.clone();
     for representation in originals {
@@ -528,36 +483,6 @@ pub mod test_support {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn maps_portable_mime_names_onto_pasteboard_types() {
-        assert_eq!(
-            native_pasteboard_type("text/plain;charset=utf-8").as_deref(),
-            Some("public.utf8-plain-text")
-        );
-        assert_eq!(
-            native_pasteboard_type("UTF8_STRING").as_deref(),
-            Some("public.utf8-plain-text")
-        );
-        assert_eq!(native_pasteboard_type("image/png").as_deref(), Some("public.png"));
-        assert_eq!(native_pasteboard_type("text/html").as_deref(), Some("public.html"));
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn passes_pasteboard_types_through_and_drops_unmappable_names() {
-        assert_eq!(
-            native_pasteboard_type("public.utf8-plain-text").as_deref(),
-            Some("public.utf8-plain-text")
-        );
-        assert_eq!(
-            native_pasteboard_type("org.webmproject.webp").as_deref(),
-            Some("org.webmproject.webp")
-        );
-        assert_eq!(native_pasteboard_type("application/x-custom"), None);
-        assert_eq!(native_pasteboard_type("NeXT TIFF v4.0 pasteboard type"), None);
-    }
 
     #[test]
     fn aliases_are_additive_and_preserve_original_bytes() {

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -250,7 +250,6 @@ impl NativeClipboard {
                         continue;
                     }
                     contents.push(ClipboardContent::Other(native, representation.data.clone()));
-                    continue;
                 }
                 #[cfg(not(target_os = "macos"))]
                 contents.push(ClipboardContent::Other(

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -223,6 +223,8 @@ impl NativeClipboard {
             contents.push(ClipboardContent::Files(native_files));
         } else {
             let mut added_files = false;
+            #[cfg(target_os = "macos")]
+            let mut published = HashSet::new();
             for representation in representations {
                 if representation.format.trim().is_empty()
                     || is_internal_marker(&representation.format)
@@ -235,6 +237,22 @@ impl NativeClipboard {
                     added_files = true;
                     continue;
                 }
+                #[cfg(target_os = "macos")]
+                {
+                    // NSPasteboard refuses any type that is not a valid UTI, and one
+                    // refused type is enough to leave the whole item empty, so map the
+                    // portable MIME names a Linux peer sends back to pasteboard types
+                    // and drop anything that has no equivalent.
+                    let Some(native) = native_pasteboard_type(&representation.format) else {
+                        continue;
+                    };
+                    if !published.insert(native.clone()) {
+                        continue;
+                    }
+                    contents.push(ClipboardContent::Other(native, representation.data.clone()));
+                    continue;
+                }
+                #[cfg(not(target_os = "macos"))]
                 contents.push(ClipboardContent::Other(
                     representation.format.clone(),
                     representation.data.clone(),
@@ -388,6 +406,51 @@ fn clipboard_file_paths(representations: &[Representation]) -> Vec<String> {
         .collect()
 }
 
+/// Maps a portable MIME name onto the macOS pasteboard type carrying the same
+/// bytes. `add_portable_aliases` is the outbound half of this pairing; without
+/// the inbound half every representation from a Wayland or X11 peer reaches
+/// NSPasteboard as an invalid UTI and the publish clears the pasteboard.
+#[cfg(target_os = "macos")]
+fn native_pasteboard_type(format: &str) -> Option<String> {
+    if is_pasteboard_type(format) {
+        return Some(format.to_owned());
+    }
+    // MIME names carry parameters such as `text/plain;charset=utf-8`.
+    let base = format
+        .split(';')
+        .next()
+        .unwrap_or(format)
+        .trim()
+        .to_ascii_lowercase();
+    let native = match base.as_str() {
+        "text/plain" | "text" | "string" | "utf8_string" => "public.utf8-plain-text",
+        "text/html" => "public.html",
+        "text/rtf" | "application/rtf" => "public.rtf",
+        "image/png" => "public.png",
+        "image/jpeg" | "image/jpg" => "public.jpeg",
+        "image/tiff" => "public.tiff",
+        "image/gif" => "com.compuserve.gif",
+        "image/heic" => "public.heic",
+        "image/heif" => "public.heif",
+        "image/webp" => "org.webmproject.webp",
+        "application/pdf" => "com.adobe.pdf",
+        "text/uri-list" => "public.file-url",
+        _ => return None,
+    };
+    Some(native.to_owned())
+}
+
+/// Recognizes the reverse-DNS UTIs a macOS peer sends, which pass through
+/// unchanged.
+#[cfg(target_os = "macos")]
+fn is_pasteboard_type(format: &str) -> bool {
+    format.contains('.')
+        && !format.contains('/')
+        && format
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '+' | '_'))
+}
+
 fn add_portable_aliases(representations: &mut Vec<Representation>, mut remaining: u64) {
     let originals = representations.clone();
     for representation in originals {
@@ -465,6 +528,36 @@ pub mod test_support {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn maps_portable_mime_names_onto_pasteboard_types() {
+        assert_eq!(
+            native_pasteboard_type("text/plain;charset=utf-8").as_deref(),
+            Some("public.utf8-plain-text")
+        );
+        assert_eq!(
+            native_pasteboard_type("UTF8_STRING").as_deref(),
+            Some("public.utf8-plain-text")
+        );
+        assert_eq!(native_pasteboard_type("image/png").as_deref(), Some("public.png"));
+        assert_eq!(native_pasteboard_type("text/html").as_deref(), Some("public.html"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn passes_pasteboard_types_through_and_drops_unmappable_names() {
+        assert_eq!(
+            native_pasteboard_type("public.utf8-plain-text").as_deref(),
+            Some("public.utf8-plain-text")
+        );
+        assert_eq!(
+            native_pasteboard_type("org.webmproject.webp").as_deref(),
+            Some("org.webmproject.webp")
+        );
+        assert_eq!(native_pasteboard_type("application/x-custom"), None);
+        assert_eq!(native_pasteboard_type("NeXT TIFF v4.0 pasteboard type"), None);
+    }
 
     #[test]
     fn aliases_are_additive_and_preserve_original_bytes() {

--- a/src/clipboard/macos.rs
+++ b/src/clipboard/macos.rs
@@ -64,6 +64,49 @@ fn publish_single_file_to(
     Ok(())
 }
 
+/// Maps a portable MIME name onto the macOS pasteboard type carrying the same
+/// bytes. `add_portable_aliases` is the outbound half of this pairing; without
+/// the inbound half every representation from a Wayland or X11 peer reaches
+/// NSPasteboard as an invalid UTI and the publish clears the pasteboard.
+pub(super) fn native_pasteboard_type(format: &str) -> Option<String> {
+    if is_pasteboard_type(format) {
+        return Some(format.to_owned());
+    }
+    // MIME names carry parameters such as `text/plain;charset=utf-8`.
+    let base = format
+        .split(';')
+        .next()
+        .unwrap_or(format)
+        .trim()
+        .to_ascii_lowercase();
+    let native = match base.as_str() {
+        "text/plain" | "text" | "string" | "utf8_string" => "public.utf8-plain-text",
+        "text/html" => "public.html",
+        "text/rtf" | "application/rtf" => "public.rtf",
+        "image/png" => "public.png",
+        "image/jpeg" | "image/jpg" => "public.jpeg",
+        "image/tiff" => "public.tiff",
+        "image/gif" => "com.compuserve.gif",
+        "image/heic" => "public.heic",
+        "image/heif" => "public.heif",
+        "image/webp" => "org.webmproject.webp",
+        "application/pdf" => "com.adobe.pdf",
+        "text/uri-list" => "public.file-url",
+        _ => return None,
+    };
+    Some(native.to_owned())
+}
+
+/// Recognizes the reverse-DNS UTIs a macOS peer sends, which pass through
+/// unchanged.
+fn is_pasteboard_type(format: &str) -> bool {
+    format.contains('.')
+        && !format.contains('/')
+        && format
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '+' | '_'))
+}
+
 fn set_data(item: &NSPasteboardItem, format: &str, bytes: &[u8]) -> Result<()> {
     let data = NSData::with_bytes(bytes);
     if !item.setData_forType(&data, &NSString::from_str(format)) {
@@ -129,6 +172,37 @@ fn detect_image_format(path: &Path, bytes: &[u8]) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn maps_portable_mime_names_onto_pasteboard_types() {
+        assert_eq!(
+            native_pasteboard_type("text/plain;charset=utf-8").as_deref(),
+            Some("public.utf8-plain-text")
+        );
+        assert_eq!(
+            native_pasteboard_type("UTF8_STRING").as_deref(),
+            Some("public.utf8-plain-text")
+        );
+        assert_eq!(native_pasteboard_type("image/png").as_deref(), Some("public.png"));
+        assert_eq!(
+            native_pasteboard_type("text/html").as_deref(),
+            Some("public.html")
+        );
+    }
+
+    #[test]
+    fn passes_pasteboard_types_through_and_drops_unmappable_names() {
+        assert_eq!(
+            native_pasteboard_type("public.utf8-plain-text").as_deref(),
+            Some("public.utf8-plain-text")
+        );
+        assert_eq!(
+            native_pasteboard_type("org.webmproject.webp").as_deref(),
+            Some("org.webmproject.webp")
+        );
+        assert_eq!(native_pasteboard_type("application/x-custom"), None);
+        assert_eq!(native_pasteboard_type("NeXT TIFF v4.0 pasteboard type"), None);
+    }
 
     #[test]
     fn publishes_a_file_url_and_image_on_the_same_pasteboard_item() {

--- a/src/clipboard/macos.rs
+++ b/src/clipboard/macos.rs
@@ -67,7 +67,7 @@ fn publish_single_file_to(
 /// Maps a portable MIME name onto the macOS pasteboard type carrying the same
 /// bytes. `add_portable_aliases` is the outbound half of this pairing; without
 /// the inbound half every representation from a Wayland or X11 peer reaches
-/// NSPasteboard as an invalid UTI and the publish clears the pasteboard.
+/// `NSPasteboard` as an invalid UTI and the publish clears the pasteboard.
 pub(super) fn native_pasteboard_type(format: &str) -> Option<String> {
     if is_pasteboard_type(format) {
         return Some(format.to_owned());


### PR DESCRIPTION
## Problem

Every clipboard transfer from a Linux peer to a macOS peer fails, and the failure is destructive: it clears whatever the macOS pasteboard already held.

`NativeClipboard::apply_sync` forwards each representation to `ClipboardContent::Other(representation.format, …)` using the format string as it arrived. From a Wayland or X11 peer those are MIME names, and NSPasteboard refuses any type that is not a valid UTI. Every flavor is refused, so the item is published with no readable data:

```
'STRING' is not a valid UTI string.  Cannot set data for an invalid UTI.
'TEXT' is not a valid UTI string.  Cannot set data for an invalid UTI.
'UTF8_STRING' is not a valid UTI string.  Cannot set data for an invalid UTI.
'text/plain' is not a valid UTI string.  Cannot set data for an invalid UTI.
'text/plain;charset=utf-8' is not a valid UTI string.  Cannot set data for an invalid UTI.
WARN ssh_clipboard::daemon: failed to apply clipboard
  error=native clipboard was empty immediately after publishing peer=home-omarchy
```

Images fail the same way on `image/png`. `ssh-clipboard monitor` on the Linux side reports the transfer as sent ("→ hades-2.local, 70 B, 5 formats"), so the loss is entirely on the apply side.

### Reproduce

1. Pair a Wayland Linux peer with a macOS peer, both on 0.2.9.
2. macOS: `printf keepme | pbcopy`, confirm `pbpaste` returns `keepme`.
3. Linux: `printf hello | wl-copy`
4. macOS: `pbpaste` returns nothing and `osascript -e 'clipboard info'` is empty. `keepme` is gone.

Also reproduced with each flavor published on its own (`wl-copy --type text/plain`, `--type 'text/plain;charset=utf-8'`, `--type UTF8_STRING`, `--type image/png`).

## Fix

`add_portable_aliases` already maps pasteboard types onto portable MIME names for the outbound direction. This adds the inbound half, `macos::native_pasteboard_type`:

- formats that already look like reverse-DNS UTIs (what a macOS peer sends) pass through untouched;
- known MIME names map to their pasteboard equivalents, mirroring the existing alias table, with MIME parameters such as `;charset=utf-8` stripped first;
- names with no equivalent are dropped rather than published, so one unknown flavor cannot empty the whole item;
- results are deduplicated, since `text/plain` and `text/plain;charset=utf-8` collapse onto the same type.

Dropping every representation leaves `contents` empty, which the existing `clipboard payload has no safe representations` guard turns into an error *before* `context.set` clears the pasteboard. So an unmappable payload now fails safe instead of destroying the user's clipboard.

Following AGENTS.md, the mapping and its tests live in `src/clipboard/macos.rs` beside the other pasteboard behavior.

## Verification

`cargo fmt --all -- --check` clean and `cargo test --all-targets` green (68 passed) on macOS 26.6.2 / arm64.

Verified live between Hyprland/Wayland and macOS 26.6.2 with the patched daemon deployed on the Mac:

| direction | text | PNG |
| --- | --- | --- |
| Linux → macOS | fixed | fixed (75 B PNG; macOS derives TIFF/JPEG/GIF/BMP from it) |
| macOS → Linux | unchanged | unchanged (73 B PNG) |

No UTI warnings remain in the macOS daemon log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUhiRrVVn61kym4LTZgtEM
